### PR TITLE
Fix module name

### DIFF
--- a/gapps.mk
+++ b/gapps.mk
@@ -16,7 +16,7 @@ PRODUCT_PACKAGES += \
        CalculatorGoogle \
        PrebuiltDeskClockGoogle \
        CalendarGooglePrebuilt \
-       GoogleHome \
+       GoogleNow \
        LatinImeGoogle \
        phh-overrides
 


### PR DESCRIPTION
GoogleHome was renamed to GoogleNow.

  https://github.com/opengapps/aosp_build/commit/111a2743