### PR TITLE
Revert "Force lawnchair instead of AOSP launcher"

### DIFF
--- a/base.mk
+++ b/base.mk
@@ -132,6 +132,3 @@ PRODUCT_PACKAGES += \
 
 PRODUCT_PACKAGES += \
 	Stk
-
-PRODUCT_PACKAGES += \
-	ch.deletescape.lawnchair.plah


### PR DESCRIPTION
This reverts commit 4b1aea0437e9c9ff8d3959b05ffb5f685cc066fa.

This broke navigation gestures, with no easy fix