### PR TITLE
Be compatible with AOSP master BOARD_SYSTEMIMAGE_PARTITION_RESERVED_SIZE

### DIFF
--- a/phhgsi_a64_a/BoardConfig.mk
+++ b/phhgsi_a64_a/BoardConfig.mk
@@ -1,5 +1,7 @@
 include build/make/target/board/generic_arm_a/BoardConfig.mk
 include device/phh/treble/board-base.mk
 
+ifeq ($(BOARD_SYSTEMIMAGE_PARTITION_RESERVED_SIZE),)
 BOARD_SYSTEMIMAGE_PARTITION_SIZE := 1572864000
+endif
 TARGET_USES_64_BIT_BINDER := true

--- a/phhgsi_arm64_a/BoardConfig.mk
+++ b/phhgsi_arm64_a/BoardConfig.mk
@@ -1,4 +1,6 @@
 include build/make/target/board/generic_arm64_a/BoardConfig.mk
 include device/phh/treble/board-base.mk
 
+ifeq ($(BOARD_SYSTEMIMAGE_PARTITION_RESERVED_SIZE),)
 BOARD_SYSTEMIMAGE_PARTITION_SIZE := 2147483648
+endif

--- a/phhgsi_arm64_ab/BoardConfig.mk
+++ b/phhgsi_arm64_ab/BoardConfig.mk
@@ -1,4 +1,6 @@
 include build/make/target/board/generic_arm64_ab/BoardConfig.mk
 include device/phh/treble/board-base.mk
 
+ifeq ($(BOARD_SYSTEMIMAGE_PARTITION_RESERVED_SIZE),)
 BOARD_SYSTEMIMAGE_PARTITION_SIZE := 2147483648
+endif

--- a/phhgsi_arm_a/BoardConfig.mk
+++ b/phhgsi_arm_a/BoardConfig.mk
@@ -1,4 +1,6 @@
 include build/make/target/board/generic_arm_a/BoardConfig.mk
 include device/phh/treble/board-base.mk
 
+ifeq ($(BOARD_SYSTEMIMAGE_PARTITION_RESERVED_SIZE),)
 BOARD_SYSTEMIMAGE_PARTITION_SIZE := 1313583104
+endif

--- a/phhgsi_arm_ab/BoardConfig.mk
+++ b/phhgsi_arm_ab/BoardConfig.mk
@@ -1,4 +1,6 @@
 include build/make/target/board/generic_arm_ab/BoardConfig.mk
 include device/phh/treble/board-base.mk
 
+ifeq ($(BOARD_SYSTEMIMAGE_PARTITION_RESERVED_SIZE),)
 BOARD_SYSTEMIMAGE_PARTITION_SIZE := 1073741824
+endif


### PR DESCRIPTION
In that case, don't enforce system image size
We will need to implement after build checks to ensure we still work on
older devices